### PR TITLE
ADD:magiclink controller to verify email after signup

### DIFF
--- a/src/controllers/LocalAuth/forgotpwd.js
+++ b/src/controllers/LocalAuth/forgotpwd.js
@@ -10,6 +10,8 @@ const moment = require("moment-timezone");
 // payload: email
 // endpoint: /forgotpassword
 
+// alternatively to send otp for verifying the email, we can use the magic link approach. after signup, their verified status will be false. when they click to send the link to verify their email address, a magic link will be send to their email address, if token matches then their status will be turned to true. they will be able to file an issue, only when isVerified is true.
+
 const forgotPwd = async (req, res) => {
   emailValidator(req, res, async () => {
     try {

--- a/src/controllers/LocalAuth/verifyemail/sendmagiclink.js
+++ b/src/controllers/LocalAuth/verifyemail/sendmagiclink.js
@@ -1,0 +1,57 @@
+const { SignUpModel } = require("../../../models/Localauth/Signup");
+const { sendEmail } = require("../../../utils/EmailService");
+const { verifyToken } = require("../../../middlewares/VerifyToken");
+const moment = require("moment-timezone");
+const crypto = require("crypto");
+
+// POST req to send magic link
+// access: private i.e after signup user will be required to login to verify their email address
+// role: all
+// payload: none
+// endpoint: /sendmagiclink
+
+const sendMagicLink = async (req, res) => {
+  verifyToken(req, res, async () => {
+    try {
+      const userId = req.user.userId;
+      if (!userId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      const user = await SignUpModel.findById(userId);
+
+      if (!user) {
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      const Email = user.email.toString().trim();
+
+      const token = crypto.randomBytes(32).toString("hex");
+      const tokenExpiration = moment
+        .tz("Asia/Kolkata")
+        .add(1, "hour")
+        .format("DD-MM-YY h:mma");
+
+      if (!token || !tokenExpiration) {
+        return res.status(400).json({ message: "Error in generating token" });
+      }
+
+      user.resetToken = token;
+      user.tokenExpiration = tokenExpiration;
+      await user.save();
+      const verifyEmailLink = `${process.env.website}/verifyemail/${token}`;
+      sendEmail(
+        Email,
+        "[Vyatha] Verify Email",
+        `Click on this link to verify your email: ${verifyEmailLink} \n Link is valid for 60 minutes \n\n Team Vyatha`
+      );
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal Server Error" });
+    }
+  });
+};
+
+module.exports = {
+  sendMagicLink,
+};

--- a/src/controllers/LocalAuth/verifyemail/verifymagiclink.js
+++ b/src/controllers/LocalAuth/verifyemail/verifymagiclink.js
@@ -1,0 +1,45 @@
+const { SignUpModel } = require("../../../models/Localauth/Signup");
+const moment = require("moment-timezone");
+
+// PUT req to verify magic link
+// access: public
+// role: all
+// payload: token as params
+// endpoint: /verifyemail/:token
+
+const verifyMagicLink = async (req, res) => {
+  try {
+    const token = req.params.token;
+    if (!token) {
+      return res.status(400).json({ message: "Token missing" });
+    }
+
+    const user = await SignUpModel.findOne({
+      resetToken: token,
+    });
+
+    if (!user) {
+      return res.status(400).json({ message: "no user exists" });
+    }
+
+    const tokenExpiration = user.tokenExpiration;
+    const currentTime = moment.tz("Asia/Kolkata").format("DD-MM-YY h:mma");
+    if (currentTime > tokenExpiration) {
+      return res.status(400).json({ message: "Token expired" });
+    } else {
+      // token is valid; proceed to verify the email address i.e make isVerified = true
+      user.isVerified = true;
+      user.resetToken = undefined;
+      user.tokenExpiration = undefined;
+      await user.save();
+      return res.status(200).json({ message: "Email verified" });
+    }
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Internal Server Error" });
+  }
+};
+
+module.exports = {
+  verifyMagicLink,
+};

--- a/src/models/Localauth/Signup.js
+++ b/src/models/Localauth/Signup.js
@@ -43,6 +43,10 @@ const SignUpSchema = new mongoose.Schema({
     type: String,
     default: undefined,
   },
+  isVerified: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const SignUpModel = mongoose.model("UserSignup", SignUpSchema);

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -39,6 +39,12 @@ const { sendotp } = require("../controllers/LocalAuth/sendotp");
 const { verifyOtp } = require("../controllers/LocalAuth/verifyotp");
 const { forgotPwd } = require("../controllers/LocalAuth/forgotpwd");
 const { resetPassword } = require("../controllers/LocalAuth/resetpassword");
+const {
+  verifyMagicLink,
+} = require("../controllers/LocalAuth/verifyemail/verifymagiclink");
+const {
+  sendMagicLink,
+} = require("../controllers/LocalAuth/verifyemail/sendmagiclink");
 
 // get
 router.get("/", home.home); // tested
@@ -60,6 +66,7 @@ router.post("/sendotp", sendotp);
 router.post("/verifyotp", verifyOtp);
 router.post("/forgotpassword", forgotPwd);
 router.post("/resetpassword/:token", resetPassword);
+router.post("/sendmagiclink", sendMagicLink);
 
 // put
 router.put("/forwardissue", forwardIssue);
@@ -72,6 +79,7 @@ router.put("/editprofile", editPrfoile);
 router.put("/closeissue", closeIssue);
 router.put("/editcomment/:issueID/:commentID", editComment);
 router.put("/approveissue", approveIssue);
+router.put("/verifyemail/:token", verifyMagicLink);
 
 //delete
 router.delete("/deleteaccount", deleteAccount);


### PR DESCRIPTION
this PR adds the capability to verify the email address using magic link, instead of OTP. after signup user will be required to login, and click on verify email button from dashboard. A standard approach used in many websites.